### PR TITLE
Fix: Resolve SVG unterminated string and attempt to fix Tailwind laye…

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,6 @@
 // postcss.config.js
 export default {
     plugins: {
-      tailwindcss: {},
       autoprefixer: {},
     },
   };

--- a/src/app.css
+++ b/src/app.css
@@ -1,8 +1,3 @@
-/* src/app.css */
-
-/*---------------------------------------------------------
-  Tailwind directives
----------------------------------------------------------*/
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -108,10 +103,7 @@
     /* focus and dark:focus variants omitted as per instructions */
 
     /* GREY caret for light mode */
-    background-image: url('data:image/svg+xml;utf8,\
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%236b7280">\
-<path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/>\
-</svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%236b7280"><path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/></svg>');
     background-size: 1em 1em;
     background-position: right 0.25rem center;
 
@@ -129,10 +121,7 @@
 
   /* -- White caret override for dark mode -- */
   .dark .ui-select {
-    background-image: url('data:image/svg+xml;utf8,\
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%23ffffff">\
-<path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/>\
-</svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%23ffffff"><path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/></svg>');
   }
 
   /* ---------- option / optgroup ---------- */


### PR DESCRIPTION
…r issue

This commit addresses two primary CSS build errors:

1.  **Unterminated string in SVG data URI (Fixed)**: I modified `src/app.css` to consolidate multi-line SVG `background-image` data URIs onto single lines. This resolved the build error: `[@tailwindcss/vite:generate:build] Unterminated string: 'data:image/svg+xml;utf8,...'`

2.  **Tailwind @layer base / @tailwind base directive issue (Attempted Fixes)**: The build also failed with: `[vite:css] [postcss] ... @layer base is used but no matching @tailwind base directive is present.`

    I took multiple steps to address this:
    *   I ensured `@tailwind base;`, `@tailwind components;`, and `@tailwind utilities;`
        are the absolute first lines in `src/app.css`.
    *   I experimented with the order of `tailwindcss()` and `sveltekit()` Vite plugins
        in `vite.config.js`. The final configuration is `tailwindcss()` followed by `sveltekit()`.
    *   I removed `tailwindcss: {}` from `postcss.config.js` to prevent potential
        conflicts with the `@tailwindcss/vite` plugin, leaving only `autoprefixer`.

The SVG error is resolved. However, the `@layer base` issue may persist. The error message for the layer issue (`.../app/src/app.css:2:11928: ...`) has a line/column number inconsistent with the source file, suggesting it occurs after CSS transformation. Further investigation might be needed if the build still fails, potentially looking into `@tailwindcss/vite` plugin options or SvelteKit's CSS processing specifics.