### PR TITLE
Fix: Resolve SVG error, attempt to fix Tailwind @layer base issue

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,15 +1,6 @@
-/* src/app.css */
-
-/*---------------------------------------------------------
-  Tailwind directives
----------------------------------------------------------*/
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/*---------------------------------------------------------
-  Theme variables
----------------------------------------------------------*/
 @layer base {
   :root {
     /* ---------- Light theme ---------- */
@@ -108,10 +99,7 @@
     /* focus and dark:focus variants omitted as per instructions */
 
     /* GREY caret for light mode */
-    background-image: url('data:image/svg+xml;utf8,\
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%236b7280">\
-<path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/>\
-</svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%236b7280"><path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/></svg>');
     background-size: 1em 1em;
     background-position: right 0.25rem center;
 
@@ -129,10 +117,7 @@
 
   /* -- White caret override for dark mode -- */
   .dark .ui-select {
-    background-image: url('data:image/svg+xml;utf8,\
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%23ffffff">\
-<path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/>\
-</svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="%23ffffff"><path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/></svg>');
   }
 
   /* ---------- option / optgroup ---------- */


### PR DESCRIPTION
This commit includes several changes to address build errors:

1.  **SVG Data URI Fix (Successful)**: I corrected `background-image` properties in `src/app.css` by ensuring SVG data URIs are on a single line. This resolved the "Unterminated string" build error.

2.  **Tailwind CSS and PostCSS Configuration (Best Practices Applied)**:
    *   I ensured `@tailwind base;`, `@tailwind components;`, and `@tailwind utilities;`
        are the absolute first lines in `src/app.css`.
    *   I removed any intervening comments or blank lines between `@tailwind utilities;`
        and the first `@layer base {` declaration in `src/app.css`.
    *   I verified `postcss.config.js` includes `tailwindcss: {}` and `autoprefixer: {}`.
    *   I verified `vite.config.js` plugin order is `tailwindcss(), sveltekit()`.

**Persistent Issue: `@layer base` error**
Despite these changes, the following error persists: `[vite:css] [postcss] /app/src/app.css:2:11928: @layer base is used but no matching @tailwind base directive is present.`

The line and column number in this error are misleading and likely point to a transformed or bundled state of the CSS. The root cause is suspected to be a systemic issue within the Vite/SvelteKit/Tailwind build pipeline, possibly related to how CSS is aggregated or how the `@tailwindcss/vite` plugin interacts with the specific versions of other dependencies.

The applied changes are beneficial for CSS structure and resolve one of the build errors. However, the primary `@layer base` issue requires further investigation, potentially by debugging the build process more deeply or researching known issues with the specific dependency versions used in your project.