### PR TITLE
Fix: Ensure clean build directories in CI workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -172,6 +172,19 @@ jobs:
           ls -R ./sidecar
         shell: bash
 
+      - name: Clean target sidecar directory
+        run: |
+          echo "Cleaning src-tauri/sidecar/ directory..."
+          if [ -d "src-tauri/sidecar" ]; then
+            # Remove contents of sidecar directory.
+            # Using find to delete contents to avoid issues if sidecar itself is a symlink or special.
+            find src-tauri/sidecar/ -mindepth 1 -delete
+            echo "src-tauri/sidecar/ cleaned."
+          else
+            echo "src-tauri/sidecar/ directory does not exist, skipping cleanup."
+          fi
+        shell: bash
+
       - name: Copy and rename sidecars
         run: |
           mkdir -p src-tauri/sidecar src-tauri/models
@@ -232,6 +245,9 @@ jobs:
           fi
         shell: bash
 
+      - name: Clean frontend build directory
+        run: rm -rf build/
+        shell: bash
 
       - name: Build frontend
         run: |


### PR DESCRIPTION
Add explicit steps to the CI workflow to clean build directories before generating new artifacts. This addresses potential issues where stale files might be included in the final build.

Changes:
- Added a step to remove the `build/` directory before the frontend build (`npm run build`).
- Added a step to clean the `src-tauri/sidecar/` directory before new sidecar binaries are moved into it.

These changes aim to make the build process more robust and ensure that only fresh artifacts are packaged.