### PR TITLE
Fix: Ensure RightInfoPanel remains visible in TableView

### DIFF
--- a/src/lib/components/projectview/notes/tables/TableView.svelte
+++ b/src/lib/components/projectview/notes/tables/TableView.svelte
@@ -38,7 +38,7 @@
     </div>
 
     <!-- Middle Panel - The Table Viewer -->
-    <div class="h-full flex-grow">
+    <div class="h-full flex-grow min-w-0"> <!-- Added min-w-0 here -->
         {#key itemPath} {#if itemPath}
              <TableViewerPanel tablePath={itemPath} />
         {:else}


### PR DESCRIPTION
The RightInfoPanel in the TableView was being pushed out of view when the table content was too wide.

This was caused by the middle panel (TableViewerPanel) expanding beyond its allocated flex space.

The fix involves adding `min-w-0` to the div wrapping the `TableViewerPanel` in `TableView.svelte`. This allows the flex item to shrink correctly and prevents it from pushing out the RightInfoPanel. The `TableViewerPanel` itself has appropriate `overflow-auto` styling to handle wide table content with a scrollbar.