### PR TITLE
fix(build): Correct GitHub Actions build failures

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -115,7 +115,8 @@ fn main() {
     let pandoc_dest_path = sidecar_dir.join(&pandoc_final_name);
     if !pandoc_dest_path.exists() {
         let pandoc_asset_part = match target.as_str() {
-            "aarch64-apple-darwin" | "x86_64-apple-darwin" => "macOS",
+            "aarch64-apple-darwin" => "arm64-macOS",
+            "x86_64-apple-darwin" => "x86_64-macOS",
             "x86_64-pc-windows-msvc" => "windows-x86_64",
             "aarch64-pc-windows-msvc" => "windows-arm64",
             "x86_64-unknown-linux-gnu" => "linux-amd64",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,6 +76,7 @@ pub fn run() {
                  }
             }
             #[cfg(target_os = "macos")]
+            {
             
 
             // log::info!("[SETUP] Preparing to set up global shortcuts..."); // Removed
@@ -128,6 +129,7 @@ pub fn run() {
             // log::info!("[SETUP] F8 shortcut registered."); // Removed
             app_mut_ref.global_shortcut().register(f9_shortcut)?;
             log::info!("Global media shortcuts (F7, F8, F9) registration process completed successfully."); // Added concise summary
+            }
 
             Ok(())
          })


### PR DESCRIPTION
This commit addresses two separate issues that were causing the CI build to fail on macOS and Windows.

- **macOS build failure:** The `build.rs` script was constructing an incorrect download URL for Pandoc on macOS, as it was missing the architecture string (`arm64` or `x86_64`). This has been corrected to use the proper asset name format.

- **Windows build failure:** The global shortcut registration logic in `src/lib.rs` was intended for macOS only but was partially compiled on Windows, causing a scope error. The entire feature has been wrapped in a `#[cfg(target_os = "macos")]` block to ensure it is excluded from non-macOS builds.