### PR TITLE
fix(ci): temporarily disable dmg bundling for macos

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["app"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
To diagnose the macOS bundling failure in GitHub Actions, this commit temporarily modifies `src-tauri/tauri.conf.json` to only build the `.app` target and disable DMG creation. This will help determine if the issue lies with the `.app` creation itself or specifically with the DMG generation process.