### PR TITLE
fix(ci): revert temporary macos bundling changes and disable windows …

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         arch: [x64, arm64]
+        exclude:
+          - os: windows-latest
+            arch: arm64
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -47,8 +50,6 @@ jobs:
           elif [ "${{ matrix.os }}" = "windows-latest" ]; then
             if [ "${{ matrix.arch }}" = "x64" ]; then
               echo "triple=x86_64-pc-windows-msvc" >> $GITHUB_OUTPUT
-            else
-              echo "triple=aarch64-pc-windows-msvc" >> $GITHUB_OUTPUT
             fi
           fi
         shell: bash

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,7 +35,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app"],
+    "targets": "all",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
…arm64

This commit reverts the temporary diagnostic changes made to macOS bundling and disables Windows ARM64 builds in the GitHub Actions workflow.

- `src-tauri/tauri.conf.json`: Reverted `bundle.targets` from `["app"]` back to `"all"` to re-enable full macOS bundling (both `.app` and `.dmg`).

- `.github/workflows/ci-build.yml`:

  - Re-added the `exclude` rule for `windows-latest` and `arm64` to the build matrix, effectively disabling Windows ARM64 builds due to an unavailable pandoc dependency.

  - Removed `aarch64-pc-windows-msvc` from the `Set target triple` step to align with the disabled Windows ARM64 builds.

  - Re-added the `Find macOS DMG`, `Upload macOS DMG`, `Zip macOS App`, and `Upload macOS App Zip` steps, which are now necessary as DMG bundling is re-enabled.

These changes will allow for a more detailed error log for the `bundle_dmg.sh` failure on macOS, which was previously obscured.