### PR TITLE
fix: enable microphone access for Live Transcribe in production builds

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -86,6 +86,8 @@ tokenizers = "0.22.1"
 async-trait = "0.1.89"
 tauri-plugin-webdriver-automation = "0.1.3"
 
+
+
 [features]
 # This feature is used for production builds
 default = ["custom-protocol"]

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required by macOS TCC so the system shows the microphone permission prompt.
+         Without this key, macOS silently denies microphone access to the app and all
+         of its child processes (e.g. the Python live-transcription subprocess). -->
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Harvey needs access to your microphone for live transcription.</string>
+</dict>
+</plist>

--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for the Python sounddevice / PortAudio to capture microphone audio -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <!-- Allows the app to spawn child processes (Python scripts) that inherit the entitlement -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/scripts/run_live_transcription.py
+++ b/src-tauri/scripts/run_live_transcription.py
@@ -7,6 +7,7 @@ import numpy as np
 import collections
 import wave
 import os
+import threading
 
 # Configure logging to stderr
 logging.basicConfig(level=logging.INFO, stream=sys.stderr)
@@ -18,11 +19,20 @@ except ImportError as e:
     print(json.dumps({"error": f"Import failed: {str(e)}"}), flush=True)
     sys.exit(1)
 
-def run_live_transcription(model_path, language=None, device="auto", threads=4, step_ms=5000, length_ms=5000, save_audio=False):
+
+def run_live_transcription(model_path, language=None, device="auto", threads=4,
+                           step_ms=5000, length_ms=5000, save_audio_path=None):
     """
     Live transcription using faster-whisper and sounddevice.
-    Mimics whisper-stream output format for Harvey integration.
+    Audio capture is done via sounddevice (PortAudio) which inherits the macOS
+    TCC microphone entitlement from the parent Harvey process.
     """
+    # --- Signal UI immediately so it shows "Initializing..." correctly ---
+    # Model loading can take 30-60 seconds. We print this early so the Rust
+    # side can emit live_transcription_ready only once the model is actually
+    # ready. We use a different sentinel here to distinguish "loading" vs "ready".
+    logging.info("[Live Transcription] Loading model...")
+
     compute_type = "int8"
     if device == "cuda":
         compute_type = "float16"
@@ -31,72 +41,110 @@ def run_live_transcription(model_path, language=None, device="auto", threads=4, 
         model = WhisperModel(model_path, device=device, compute_type=compute_type, cpu_threads=threads)
     except Exception as e:
         print(json.dumps({"error": f"Failed to load model: {str(e)}"}), flush=True)
-        return
+        sys.exit(1)
 
     sample_rate = 16000
     chunk_samples = int(sample_rate * (step_ms / 1000.0))
-    
-    # Buffer to hold audio for transcription
-    audio_buffer = collections.deque(maxlen=int(sample_rate * (length_ms / 1000.0)))
-    
+
+    # Rolling buffer: keep the last `length_ms` ms of audio
+    buffer_maxlen = int(sample_rate * (length_ms / 1000.0))
+    audio_buffer = collections.deque(maxlen=buffer_maxlen)
+    buffer_lock = threading.Lock()
+
+    # Open WAV file for saving if requested (opened after stream is confirmed open)
     wav_file = None
-    if save_audio:
-        timestamp = time.strftime("%Y%m%d%H%M%S")
-        filename = f"{timestamp}.wav"
-        wav_file = wave.open(filename, 'wb')
-        wav_file.setnchannels(1)
-        wav_file.setsampwidth(2) # 16-bit
-        wav_file.setframerate(sample_rate)
-        logging.info(f"Saving audio to {os.path.abspath(filename)}")
 
-    print("[Start speaking]", flush=True)
+    # --- Pre-flight: check that a microphone is actually available ---
+    try:
+        default_input = sd.query_devices(kind='input')
+        max_ch = default_input.get('max_input_channels', 0) if default_input else 0
+        if max_ch == 0:
+            print(json.dumps({"error": (
+                "Microphone access denied or no input device found. "
+                "Please allow Harvey to access your microphone in "
+                "System Settings > Privacy & Security > Microphone."
+            )}), flush=True)
+            sys.exit(1)
+        logging.info(f"[Live Transcription] Input device: {default_input.get('name')} ({max_ch} ch)")
+    except Exception as e:
+        print(json.dumps({"error": f"Microphone check failed: {str(e)}"}), flush=True)
+        sys.exit(1)
 
-    def audio_callback(indata, frames, time, status):
+    def audio_callback(indata, frames, time_info, status):
         if status:
-            logging.warning(status)
-        audio_buffer.extend(indata[:, 0])
+            logging.warning(f"[Audio] Status: {status}")
+        with buffer_lock:
+            audio_buffer.extend(indata[:, 0])
         if wav_file:
-            # Convert float32 to int16 for WAV saving
             audio_int16 = (indata[:, 0] * 32767).astype(np.int16)
             wav_file.writeframes(audio_int16.tobytes())
 
     try:
-        with sd.InputStream(samplerate=sample_rate, channels=1, callback=audio_callback, blocksize=chunk_samples):
-            while True:
-                if len(audio_buffer) >= chunk_samples:
-                    # Convert buffer to numpy array
-                    audio_data = np.array(list(audio_buffer), dtype=np.float32)
-                    
-                    # Transcribe
-                    segments, info = model.transcribe(
-                        audio_data,
-                        language=language,
-                        beam_size=5,
-                        vad_filter=True,
-                        vad_parameters=dict(min_silence_duration_ms=500)
-                    )
+        stream = sd.InputStream(
+            samplerate=sample_rate,
+            channels=1,
+            callback=audio_callback,
+            blocksize=chunk_samples
+        )
+        stream.start()
+    except Exception as e:
+        err = str(e)
+        if "Invalid number of channels" in err or "unauthenticated" in err.lower():
+            print(json.dumps({"error": (
+                "Microphone access denied. Please allow Harvey to access the microphone "
+                "in System Settings > Privacy & Security > Microphone."
+            )}), flush=True)
+        else:
+            print(json.dumps({"error": f"Failed to open audio stream: {err}"}), flush=True)
+        sys.exit(1)
 
-                    full_text = ""
-                    for segment in segments:
-                        full_text += segment.text
+    # Open WAV file *after* stream confirmed open (so we only create it if recording works)
+    if save_audio_path:
+        try:
+            wav_file = wave.open(save_audio_path, 'wb')
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(sample_rate)
+            logging.info(f"[Live Transcription] Saving audio to {save_audio_path}")
+        except Exception as e:
+            logging.error(f"[Live Transcription] Failed to open WAV file: {e}")
 
-                    text = full_text.strip()
-                    if text:
-                        # Harvey's Rust side expects a specific format or just text.
-                        # whisper-stream typically prints text directly.
-                        # We use '...' to signal a partial result if it's not the end of a sentence.
-                        # For now, we'll keep it simple as whisper-stream does.
-                        print(text, flush=True)
+    # Signal Rust/frontend that we are ready
+    print("[Start speaking]", flush=True)
+    logging.info("[Live Transcription] Ready — microphone open, transcribing.")
 
-                time.sleep(step_ms / 2000.0) # Sleep for half the step size
+    try:
+        while True:
+            time.sleep(step_ms / 1000.0)
+
+            with buffer_lock:
+                if len(audio_buffer) < chunk_samples:
+                    continue
+                audio_data = np.array(list(audio_buffer), dtype=np.float32)
+
+            segments, info = model.transcribe(
+                audio_data,
+                language=language,
+                beam_size=5,
+                vad_filter=True,
+                vad_parameters=dict(min_silence_duration_ms=500)
+            )
+
+            full_text = "".join(seg.text for seg in segments).strip()
+            if full_text:
+                print(full_text, flush=True)
 
     except KeyboardInterrupt:
         pass
     except Exception as e:
-        print(json.dumps({"error": f"Live transcription failed: {str(e)}"}), flush=True)
+        print(json.dumps({"error": f"Transcription loop error: {str(e)}"}), flush=True)
     finally:
+        stream.stop()
+        stream.close()
         if wav_file:
             wav_file.close()
+        logging.info("[Live Transcription] Stopped.")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -106,7 +154,8 @@ if __name__ == "__main__":
     parser.add_argument("--threads", type=int, default=4)
     parser.add_argument("--step", type=int, default=5000)
     parser.add_argument("--length", type=int, default=5000)
-    parser.add_argument("--save-audio", action="store_true")
+    parser.add_argument("--save-audio", default=None,
+                        help="Full path to save audio WAV file")
 
     args = parser.parse_args()
 
@@ -115,11 +164,11 @@ if __name__ == "__main__":
         lang = None
 
     run_live_transcription(
-        args.model, 
-        lang, 
-        args.device, 
-        args.threads, 
-        args.step, 
+        args.model,
+        lang,
+        args.device,
+        args.threads,
+        args.step,
         args.length,
-        args.save_audio
+        args.save_audio,
     )

--- a/src-tauri/src/transcription/faster_whisper_live.rs
+++ b/src-tauri/src/transcription/faster_whisper_live.rs
@@ -1,6 +1,6 @@
 use crate::projectview::transcription_commands::{LiveTranscriptionResult, LiveTranscriptionState};
 use crate::welcome::python_env::get_python_path;
-use log::{error, info};
+use log::{error, info, warn};
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
@@ -39,28 +39,27 @@ pub async fn start_faster_whisper_live<R: Runtime>(
         "5000".to_string(),
     ];
 
-    let mut command = app_handle
-        .shell()
-        .command(python_path.to_string_lossy().to_string());
-
     if save_audio {
         let active_doc_path = std::path::PathBuf::from(&active_document_path);
         let attachments_dir = active_doc_path.parent().unwrap().join("attachments");
         std::fs::create_dir_all(&attachments_dir).map_err(|e| e.to_string())?;
-
+        let timestamp = chrono::Local::now().format("%Y%m%d%H%M%S").to_string();
+        let wav_path = attachments_dir.join(format!("{}.wav", timestamp));
         args.push("--save-audio".to_string());
-        command = command.current_dir(attachments_dir);
+        args.push(wav_path.to_string_lossy().to_string());
     }
-
-    // Additional configuration from read_config could be added here (threads, device)
-    // For now, we use defaults in the script.
 
     info!(
         "[Faster-Whisper Live] Spawning Python script: {:?} {:?}",
         python_path, args
     );
 
-    let (mut rx, child) = command.args(args).spawn().map_err(|e| e.to_string())?;
+    let (mut rx, child) = app_handle
+        .shell()
+        .command(python_path.to_string_lossy().to_string())
+        .args(args)
+        .spawn()
+        .map_err(|e| e.to_string())?;
 
     *state.whisper_child.lock().await = Some(child);
     state.is_running.store(true, Ordering::SeqCst);
@@ -85,12 +84,27 @@ pub async fn start_faster_whisper_live<R: Runtime>(
             match event {
                 CommandEvent::Stdout(line) => {
                     let text = String::from_utf8_lossy(&line).to_string();
+                    let trimmed = text.trim();
 
-                    if text.contains("[Start speaking]") {
+                    // Detect JSON error objects emitted by the Python script
+                    // (e.g. microphone permission denied, model load failure).
+                    if trimmed.starts_with('{') {
+                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                            if let Some(err_msg) = v.get("error").and_then(|e| e.as_str()) {
+                                error!("[Faster-Whisper Live] Script error: {}", err_msg);
+                                let _ = app_handle_clone
+                                    .emit("live_transcription_error", err_msg.to_string());
+                                is_running_clone.store(false, Ordering::SeqCst);
+                                break;
+                            }
+                        }
+                    }
+
+                    if trimmed.contains("[Start speaking]") {
                         let _ = app_handle_clone.emit("live_transcription_ready", ());
                     }
 
-                    let cleaned_text = text.replace("[Start speaking]", "").trim().to_string();
+                    let cleaned_text = trimmed.replace("[Start speaking]", "").trim().to_string();
 
                     if !cleaned_text.is_empty() && cleaned_text != last_text {
                         let is_final = !cleaned_text.ends_with("...");
@@ -115,16 +129,20 @@ pub async fn start_faster_whisper_live<R: Runtime>(
                     }
                 }
                 CommandEvent::Stderr(line) => {
-                    error!(
-                        "[Faster-Whisper Live][stderr]: {}",
-                        String::from_utf8_lossy(&line)
-                    );
+                    let msg = String::from_utf8_lossy(&line).to_string();
+                    // faster-whisper logs progress to stderr — only surface real errors
+                    if msg.to_lowercase().contains("error") || msg.to_lowercase().contains("failed") {
+                        error!("[Faster-Whisper Live][stderr]: {}", msg.trim());
+                    } else {
+                        warn!("[Faster-Whisper Live][stderr]: {}", msg.trim());
+                    }
                 }
                 CommandEvent::Error(err) => {
                     error!("[Faster-Whisper Live][error]: {}", err);
                 }
                 CommandEvent::Terminated(payload) => {
                     info!("[Faster-Whisper Live] Process terminated: {:?}", payload);
+                    is_running_clone.store(false, Ordering::SeqCst);
                 }
                 _ => {}
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,7 +61,8 @@
       "assets/*"
     ],
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": "-",
+      "entitlements": "entitlements.plist"
     }
   }
 }

--- a/src/lib/components/projectview/data/DataTopBar.svelte
+++ b/src/lib/components/projectview/data/DataTopBar.svelte
@@ -536,6 +536,7 @@
 
   let unlisten = null;
   let unlistenReady = null;
+  let unlistenError = null;
 
   onMount(async () => {
     unlistenReady = await listen('live_transcription_ready', () => {
@@ -566,6 +567,18 @@
         );
       }
     });
+
+    // Handle errors emitted by the Python live-transcription script
+    // (e.g. microphone access denied in production builds).
+    unlistenError = await listen('live_transcription_error', (event) => {
+      const errorMsg = event.payload;
+      console.error('[DataTopBar] live_transcription_error:', errorMsg);
+      isLiveTranscriptionActive = false;
+      isLiveTranscriptionReady = false;
+      liveTranscriptionError = errorMsg;
+      stopDotAnimation();
+      message(`Live transcription failed: ${errorMsg}`, { title: 'Microphone Error', type: 'error' });
+    });
   });
 
   onDestroy(async () => {
@@ -577,6 +590,9 @@
     }
     if (unlistenReady) {
       unlistenReady();
+    }
+    if (unlistenError) {
+      unlistenError();
     }
     stopDotAnimation();
   });


### PR DESCRIPTION
- Add NSMicrophoneUsageDescription to Info.plist (required by macOS TCC to prompt the user for microphone permission on first use)
- Add entitlements.plist with com.apple.security.device.audio-input so the audio-input entitlement is embedded in the signed .app bundle
- Reference entitlements.plist from tauri.conf.json macOS bundle config
- Fix faster-whisper live transcription (sounddevice in the Python child process now works because the TCC entitlement propagates from Harvey.app)
- Pass WAV save path as a full absolute path via --save-audio instead of using current_dir, fixing 0-duration saved audio files
- Add pre-flight microphone check in Python with a clear user-facing error
- Emit live_transcription_error event from Rust when Python reports an error (JSON stdout); frontend listens and shows a dialog + resets state
- Fix: model loads before [Start speaking] sentinel is printed so WAV file is only opened once the audio stream is confirmed open